### PR TITLE
Path cleanup

### DIFF
--- a/all_run.sh
+++ b/all_run.sh
@@ -16,7 +16,7 @@
 
 LATEST_VERSION=53
 VERSION=${1:-$LATEST_VERSION} # Get version from command line if provided
-CMDSTAN_ARGS="--cmdstanr --include-paths=~/Code/takeup/stan_models"
+CMDSTAN_ARGS="--cmdstanr --include-paths=stan_models"
 SLURM_INOUT_DIR=~/scratch-midway2
 
 if [[ -v IN_SLURM ]]; then
@@ -31,7 +31,7 @@ if [[ -v IN_SLURM ]]; then
   echo "Running with ${CORES} cores."
   echo "INOUT ARGS: ${POSTPROCESS_INOUT_ARGS}."
 else
-  OUTPUT_ARGS="--output-path=~/Code/takeup/data/stan_analysis_data"
+  OUTPUT_ARGS="--output-path=data/stan_analysis_data"
   POSTPROCESS_INOUT_ARGS=
   CORES=12
 fi
@@ -39,13 +39,13 @@ fi
 STAN_THREADS=$((${CORES} / 4))
 
 # Distance
-#Rscript ./run_takeup.R dist prior --chains=4 --iter 800 --outputname=dist_model_prior --output-path=~/Code/takeup/data/stan_analysis_data --include-paths=~/Code/takeup/stan_models --num-mix-groups=1 --multilevel &
-#Rscript ./run_takeup.R dist fit   --chains=4 --iter 800 --outputname=dist_model_fit   --output-path=~/Code/takeup/data/stan_analysis_data --include-paths=~/Code/takeup/stan_models --num-mix-groups=1 --multilevel
+#Rscript ./run_takeup.R dist prior --chains=4 --iter 800 --outputname=dist_model_prior --output-path=data/stan_analysis_data --include-paths=stan_models --num-mix-groups=1 --multilevel &
+#Rscript ./run_takeup.R dist fit   --chains=4 --iter 800 --outputname=dist_model_fit   --output-path=data/stan_analysis_data --include-paths=stan_models --num-mix-groups=1 --multilevel
 #wait
 
 # Beliefs
-#Rscript ./run_takeup.R beliefs prior --chains=4 --iter 1000 --outputname=beliefs_prior --output-path=~/Code/takeup/data/stan_analysis_data --include-paths=~/Code/takeup/stan_models &
-#Rscript ./run_takeup.R beliefs fit   --chains=4 --iter 1000 --outputname=beliefs       --output-path=~/Code/takeup/data/stan_analysis_data --include-paths=~/Code/takeup/stan_models --num-mix-groups=1
+#Rscript ./run_takeup.R beliefs prior --chains=4 --iter 1000 --outputname=beliefs_prior --output-path=data/stan_analysis_data --include-paths=stan_models &
+#Rscript ./run_takeup.R beliefs fit   --chains=4 --iter 1000 --outputname=beliefs       --output-path=data/stan_analysis_data --include-paths=stan_models --num-mix-groups=1
 #wait
 
 # Reduced Form 

--- a/all_run.sh
+++ b/all_run.sh
@@ -16,7 +16,7 @@
 
 LATEST_VERSION=53
 VERSION=${1:-$LATEST_VERSION} # Get version from command line if provided
-CMDSTAN_ARGS="--cmdstanr --include-paths=~/Code/takeup/stan_models"
+CMDSTAN_ARGS="--cmdstanr --include-paths=stan_models"
 SLURM_INOUT_DIR=~/scratch-midway2
 
 if [[ -v IN_SLURM ]]; then
@@ -31,7 +31,7 @@ if [[ -v IN_SLURM ]]; then
   echo "Running with ${CORES} cores."
   echo "INOUT ARGS: ${POSTPROCESS_INOUT_ARGS}."
 else
-  OUTPUT_ARGS="--output-path=~/Code/takeup/data/stan_analysis_data"
+  OUTPUT_ARGS="--output-path=stan_analysis_data"
   POSTPROCESS_INOUT_ARGS=
   CORES=12
 fi
@@ -39,13 +39,13 @@ fi
 STAN_THREADS=$((${CORES} / 4))
 
 # Distance
-#Rscript ./run_takeup.R dist prior --chains=4 --iter 800 --outputname=dist_model_prior --output-path=~/Code/takeup/data/stan_analysis_data --include-paths=~/Code/takeup/stan_models --num-mix-groups=1 --multilevel &
-#Rscript ./run_takeup.R dist fit   --chains=4 --iter 800 --outputname=dist_model_fit   --output-path=~/Code/takeup/data/stan_analysis_data --include-paths=~/Code/takeup/stan_models --num-mix-groups=1 --multilevel
+#Rscript ./run_takeup.R dist prior --chains=4 --iter 800 --outputname=dist_model_prior --output-path=data/stan_analysis_data --include-paths=stan_models --num-mix-groups=1 --multilevel &
+#Rscript ./run_takeup.R dist fit   --chains=4 --iter 800 --outputname=dist_model_fit   --output-path=data/stan_analysis_data --include-paths=stan_models --num-mix-groups=1 --multilevel
 #wait
 
 # Beliefs
-#Rscript ./run_takeup.R beliefs prior --chains=4 --iter 1000 --outputname=beliefs_prior --output-path=~/Code/takeup/data/stan_analysis_data --include-paths=~/Code/takeup/stan_models &
-#Rscript ./run_takeup.R beliefs fit   --chains=4 --iter 1000 --outputname=beliefs       --output-path=~/Code/takeup/data/stan_analysis_data --include-paths=~/Code/takeup/stan_models --num-mix-groups=1
+#Rscript ./run_takeup.R beliefs prior --chains=4 --iter 1000 --outputname=beliefs_prior --output-path=data/stan_analysis_data --include-paths=stan_models &
+#Rscript ./run_takeup.R beliefs fit   --chains=4 --iter 1000 --outputname=beliefs       --output-path=data/stan_analysis_data --include-paths=stan_models --num-mix-groups=1
 #wait
 
 # Reduced Form 

--- a/run_takeup.R
+++ b/run_takeup.R
@@ -24,12 +24,12 @@ Options:
 "),
 
   # args = if (interactive()) "fit --sequential --outputname=dist_fit28 --update-output" else commandArgs(trailingOnly = TRUE) 
-  # args = if (interactive()) "takeup prior --sequential --outputname=test --output-path=~/Code/takeup/data/stan_analysis_data --models=STRUCTURAL_LINEAR_U_SHOCKS --cmdstanr --include-paths=~/Code/takeup/stan_models --threads=3 --num-mix-groups=1" else commandArgs(trailingOnly = TRUE)
-  # args = if (interactive()) "takeup prior --sequential --outputname=test --output-path=~/Code/takeup/data/stan_analysis_data --models=REDUCED_FORM_NO_RESTRICT --cmdstanr --include-paths=~/Code/takeup/stan_models --threads=3" else commandArgs(trailingOnly = TRUE)
-  # args = if (interactive()) "beliefs fit --chains=8 --outputname=test --output-path=~/Code/takeup/data/stan_analysis_data --include-paths=~/Code/takeup/stan_models --iter=1000" else commandArgs(trailingOnly = TRUE)
-  args = if (interactive()) "takeup fit --cmdstanr --chains=1 --outputname=test --models=REDUCED_FORM_NO_RESTRICT --output-path=data/sbc_output_data --include-paths=stan_models --sequential --sbc --num-sbc-sims=8" else commandArgs(trailingOnly = TRUE)
-  # args = if (interactive()) "dist fit --chains=4 --iter 800 --outputname=test --output-path=~/Code/takeup/data/stan_analysis_data --include-paths=~/Code/takeup/stan_models --num-mix-groups=1 --multilevel" else commandArgs(trailingOnly = TRUE)
-  # args = if (interactive()) "takeup fit --cmdstanr --chains=8 --outputname=test --models=STRUCTURAL_LINEAR_U_SHOCKS --output-path=~/Code/takeup/data/stan_analysis_data --include-paths=~/Code/takeup/stan_models --sequential" else commandArgs(trailingOnly = TRUE)
+  # args = if (interactive()) "takeup prior --sequential --outputname=test --output-path=data/stan_analysis_data --models=STRUCTURAL_LINEAR_U_SHOCKS --cmdstanr --include-paths=stan_models --threads=3 --num-mix-groups=1" else commandArgs(trailingOnly = TRUE)
+  # args = if (interactive()) "takeup prior --sequential --outputname=test --output-path=data/stan_analysis_data --models=REDUCED_FORM_NO_RESTRICT --cmdstanr --include-paths=stan_models --threads=3" else commandArgs(trailingOnly = TRUE)
+  # args = if (interactive()) "beliefs fit --chains=8 --outputname=test --output-path=data/stan_analysis_data --include-paths=stan_models --iter=1000" else commandArgs(trailingOnly = TRUE)
+  args = if (interactive()) "takeup fit --cmdstanr --models=REDUCED_FORM_NO_RESTRICT --output-path=data/stan_analysis_data --include-paths=stan_models --threads=3 --update --outputname=test --multilevel --age --sequential" else commandArgs(trailingOnly = TRUE)
+  # args = if (interactive()) "dist fit --chains=4 --iter 800 --outputname=test --output-path=data/stan_analysis_data --include-paths=stan_models --num-mix-groups=1 --multilevel" else commandArgs(trailingOnly = TRUE)
+  # args = if (interactive()) "takeup fit --cmdstanr --chains=8 --outputname=test --models=STRUCTURAL_LINEAR_U_SHOCKS --output-path=data/stan_analysis_data --include-paths=stan_models --sequential" else commandArgs(trailingOnly = TRUE)
 ) 
 
 library(magrittr)
@@ -933,7 +933,6 @@ if (script_options$takeup) {
       
         # BUG spaces in paths causing problems. Wait till it is fixed.
         try(iwalk(dist_fit_obj, ~ .x$save_output_files(dir = script_options$output_path, basename = str_c(output_name, .y, sep = "_"), timestamp = FALSE, random = FALSE)))
-        
         dist_fit_obj %>% 
           iwalk(~ {
             cat(.y, "Diagnosis ---------------------------------\n")


### PR DESCRIPTION
Swaps to relative paths in `run_takeup.R` and `all_run.sh`

Checked locally and on Midway. I got these errors but pretty sure they're just because I don't have a `temp-data` folder or didn't have `dist_kfold53` already saved.


`In readChar(con, 5L, useBytes = TRUE) :
  cannot open compressed file 'data/stan_analysis_data/dist_kfold53.RData', probable reason 'No such file or directory'
Error in gzfile(file, "wb") : cannot open the connection
Calls: save -> gzfile
In addition: Warning message:
In gzfile(file, "wb") :
  cannot open compressed file 'temp-data/processed_dist_fit53.RData', probable reason 'No such file or directory'`
